### PR TITLE
Set to Django 1.4.2 until askbot is updated to work on 1.5+

### DIFF
--- a/askbot_requirements.txt
+++ b/askbot_requirements.txt
@@ -1,5 +1,5 @@
 akismet
-django>=1.4.2
+django==1.4.2
 Jinja2
 Coffin>=0.3
 South>=0.7.1


### PR DESCRIPTION
If you use Django 1.5.1 you will get this error:

error ImportError: cannot import name str_to_unicode

http://askbot.org/en/question/10016/error-importerror-cannot-import-name-str_to_unicode/

This was blocking me from deploying on Heroku.
